### PR TITLE
feat: add pgvector retriever support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,3 +25,7 @@ PINECONE_INDEX_NAME=...
 
 ## Mongo Atlas
 MONGODB_URI=... # Full connection string
+
+## pgvector
+PGVECTOR_CONNECTION_STRING=postgresql+psycopg://username:password@localhost:5432/your_database_name
+PGVECTOR_COLLECTION_NAME=langchain  # Optional, defaults to 'langchain'

--- a/README.md
+++ b/README.md
@@ -168,6 +168,71 @@ PINECONE_API_KEY=your-api-key
 PINECONE_INDEX_NAME=your-index-name
 ```
 
+#### pgvector
+
+`pgvector` is an open-source PostgreSQL extension for vector similarity search. It allows you to store and query embeddings directly within your PostgreSQL database.
+
+##### Setup pgvector
+
+1. **Install PostgreSQL and pgvector Extension:**
+
+   - Ensure you have PostgreSQL installed (version 14 or higher is recommended).
+   - Install the `pgvector` extension:
+     - For PostgreSQL 14+ on Ubuntu/Debian:
+
+       ```bash
+       # Install PostgreSQL if not installed
+       sudo apt-get install postgresql postgresql-contrib
+
+       # Install pgvector extension
+       sudo apt-get install postgresql-{postgresql-version}-pgvector
+       ```
+
+     - Alternatively, you can install from source. Follow the instructions in the [pgvector GitHub repository](https://github.com/pgvector/pgvector#installation).
+
+2. **Create a Database and Enable pgvector:**
+
+   - Create a new PostgreSQL database or use an existing one.
+
+     ```sql
+     -- In the psql shell
+     CREATE DATABASE your_database_name;
+     ```
+
+   - Connect to your database and enable the `pgvector` extension:
+
+     ```sql
+     -- Connect to your database
+     \c your_database_name
+
+     -- Enable the pgvector extension
+     CREATE EXTENSION vector;
+     ```
+
+3. **Set Up Environment Variables:**
+
+   - In your `.env` file, add the following variables:
+
+     ```
+     PGVECTOR_CONNECTION_STRING=postgresql+psycopg://username:password@localhost:5432/your_database_name
+     PGVECTOR_COLLECTION_NAME=langchain  # You can change this to your preferred collection/table name
+     ```
+
+     - Replace `username`, `password`, `localhost`, `5432`, and `your_database_name` with your actual PostgreSQL credentials and connection details.
+
+4. **Configure the Retriever Provider:**
+
+   - Update the `retriever_provider` in your configuration to use `pgvector`:
+
+     ```yaml
+     retriever_provider: pgvector
+     ```
+
+5. **Verify the Setup:**
+
+   - Ensure your application can connect to the PostgreSQL database.
+   - Test indexing and retrieval to confirm that `pgvector` is functioning correctly.
+
 
 ### Setup Model
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "msgspec>=0.18.6",
     "langchain-mongodb>=0.1.9",
     "langchain-cohere>=0.2.4",
+    "langchain-postgres>=0.0.12",
 ]
 
 [project.optional-dependencies]

--- a/src/retrieval_graph/configuration.py
+++ b/src/retrieval_graph/configuration.py
@@ -32,12 +32,13 @@ class IndexConfiguration:
     )
 
     retriever_provider: Annotated[
-        Literal["elastic", "elastic-local", "pinecone", "mongodb"],
+        Literal["elastic", "elastic-local", "pinecone", "mongodb", "pgvector"],
         {"__template_metadata__": {"kind": "retriever"}},
     ] = field(
         default="elastic",
         metadata={
-            "description": "The vector store provider to use for retrieval. Options are 'elastic', 'pinecone', or 'mongodb'."
+            "description": "The vector store provider to use for retrieval. Options are 'elastic', 'pinecone', 'mongodb', or 'pgvector'."
+
         },
     )
 


### PR DESCRIPTION
This update introduces full support for the `pgvector` retriever in the configuration module, with specific enhancements to address metadata deserialization issues in asynchronous mode. The following changes were made:

- Added `make_pgvector_retriever` to connect to a pgvector index.
- Updated `make_retriever` to support the pgvector option.
- Included async mode support in the `PGVector` initialization.
- **Enhanced `PGVector` Class**: Overridden to ensure correct metadata deserialization when using `async_mode=True`. This directly addresses the metadata handling issue as detailed in [issue #124](https://github.com/langchain-ai/langchain-postgres/issues/124) in the langchain-postgres repository.
- Enhanced type annotations and error handling for better stability.
- **README** updated to document pgvector support and usage instructions, including notes on handling metadata in async mode.
- **example.env** updated with new environment variable examples required for pgvector configuration.
- **configuration** retriever_provider updated with the `pgvector` option.

These updates enhance the robustness and functionality of the pgvector integration, ensuring reliable metadata handling and increasing flexibility and ease of use.

Related Issues

#5 