### PR TITLE
chore: add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: uv
+    directory: "/"
+    schedule:
+      interval: weekly
+    versioning-strategy: increase
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly


### PR DESCRIPTION
## Summary

- add weekly Dependabot updates for the root uv project
- add weekly Dependabot updates for GitHub Actions
- use `versioning-strategy: increase` for uv so declared bounds stay aligned with lockfile updates

## Validation

- parsed `.github/dependabot.yml` successfully with Ruby YAML
- `git diff --check`
- confirmed the PR only adds `.github/dependabot.yml`